### PR TITLE
Keywords can contain dash

### DIFF
--- a/ftplugin/jade.vim
+++ b/ftplugin/jade.vim
@@ -11,6 +11,8 @@ endif
 let s:save_cpo = &cpo
 set cpo-=C
 
+setlocal iskeyword+=-
+
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
 let s:browsefilter = "All Files (*.*)\t*.*\n"


### PR DESCRIPTION
If the cursor is over `data-link`, for example, the `gd` command will search for all occurences of “data-link” instead of “data” only.